### PR TITLE
[Mod] 保存参数优化回测结果时，将参数字典和结果字典按字段展开保存，方便后续查看与分析

### DIFF
--- a/vnpy_ctabacktester/ui/widget.py
+++ b/vnpy_ctabacktester/ui/widget.py
@@ -2,7 +2,9 @@ import csv
 from datetime import datetime, timedelta
 from copy import copy
 
+import ast
 import numpy as np
+import pandas as pd
 import pyqtgraph as pg
 
 from vnpy.trader.constant import Interval, Direction, Exchange
@@ -1032,15 +1034,11 @@ class OptimizationResultMonitor(QtWidgets.QDialog):
         if not path:
             return
 
-        with open(path, "w") as f:
-            writer = csv.writer(f, lineterminator="\n")
-
-            writer.writerow(["参数", self.target_display])
-
-            for tp in self.result_values:
-                setting, target_value, _ = tp
-                row_data = [str(setting), str(target_value)]
-                writer.writerow(row_data)
+        result_values = np.array(self.result_values)
+        setting = pd.DataFrame([ast.literal_eval(x) for x in result_values[:, 0]])
+        results = pd.DataFrame(result_values[:, 2].tolist())
+        out_data = pd.concat([setting, results], axis=1)
+        out_data.to_csv(path, index=None, encoding='gbk')
 
 
 class BacktestingTradeMonitor(BaseMonitor):


### PR DESCRIPTION
(cherry picked from commit e14f73b1811f47f477a39177c132b956d6ad03a7)

当前参数是字典形式，结果只有一个目标指标。
这在UI界面展示时没什么问题，因为UI展示的目的只是简单预览或者是因为性能。
但我觉得保存文件的时候应该提供完整的回测结果，包含所有字段，方便后续查看与分析，例如使用Excel透视表