### PR TITLE
[Mod]数据为空自动终止回测线程，优化界面体验

### DIFF
--- a/vnpy_ctabacktester/engine.py
+++ b/vnpy_ctabacktester/engine.py
@@ -186,6 +186,8 @@ class BacktesterEngine(BaseEngine):
         engine.load_data()
         if not engine.history_data:
             self.write_log("策略回测失败，历史数据为空")
+            
+            self.thread = None
             return
 
         try:


### PR DESCRIPTION
如果数据为空的话，回测结束后线程没有终止，后续改了代码或者数据范围也没法继续回测，必须重启整个客户端，体验不好。
![578478bd47f258b15be252e3f7d92e0](https://github.com/vnpy/vnpy_ctabacktester/assets/15245112/d40f9a15-73fc-4df5-9cac-9241d515d43b)
这里应该和回测报错同样处理，也自动退出线程避免阻塞后续的运行，就可以在当前界面再次运行
![image](https://github.com/vnpy/vnpy_ctabacktester/assets/15245112/82b69b62-6383-4e3a-8e94-4864d8cba24e)



