### PR TITLE
fix:修复计算回测结果数据未传参导致空数据计算失败的问题

### DIFF
--- a/vnpy_ctabacktester/engine.py
+++ b/vnpy_ctabacktester/engine.py
@@ -201,7 +201,7 @@ class BacktesterEngine(BaseEngine):
             return
 
         self.result_df = engine.calculate_result()
-        self.result_statistics = engine.calculate_statistics(output=False)
+        self.result_statistics = engine.calculate_statistics(df=self.result_df, output=False)
 
         # Clear thread object handler.
         self.thread = None


### PR DESCRIPTION
ctabacktester模块儿中，engine部分在回测完成后计算结果数据时未传参，导致空数据，最终计算失败，图表未显示，错误如下图：
![WechatIMG56](https://github.com/user-attachments/assets/4531c186-afd1-4e85-a7b0-117cbe174076)
