### PR TITLE
(fix): fix pyqtgraph df index error.

### DIFF
--- a/vnpy_ctabacktester/ui/widget.py
+++ b/vnpy_ctabacktester/ui/widget.py
@@ -817,8 +817,8 @@ class BacktesterChart(pg.GraphicsLayoutWidget):
             self.dates[n] = date
 
         # Set data for curve of balance and drawdown
-        self.balance_curve.setData(df["balance"])
-        self.drawdown_curve.setData(df["drawdown"])
+        self.balance_curve.setData(df["balance"].values)
+        self.drawdown_curve.setData(df["drawdown"].values)
 
         # Set data for daily pnl bar
         profit_pnl_x: list = []


### PR DESCRIPTION
## 改进内容

修复pyqtgraph 和 pandas 索引不兼容，报错如下：
```text
Traceback (most recent call last):

  File "site-packages/pandas/core/indexes/base.py", line 3641, in get_loc
    return self._engine.get_loc(casted_key)
           │    │               └ 0
           │    └ <pandas._libs.properties.CachedProperty object at 0x1038e8f00>
           └ Index([2020-11-11, 2020-11-12, 2020-11-13, 2020-11-16, 2020-11-17, 2020-11-18,
                    2020-11-19, 2020-11-20, 2020-11-23, 202...
  File "pandas/_libs/index.pyx", line 168, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 197, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7668, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7676, in pandas._libs.hashtable.PyObjectHashTable.get_item

KeyError: 0


The above exception was the direct cause of the following exception:


Traceback (most recent call last):

  File "/Users/pan/Project/Quant/examples/vn_trader/run.py", line 161, in <module>
    main()
    └ <function main at 0x11302fe20>

  File "/Users/pan/Project/Quant/examples/vn_trader/run.py", line 157, in main
    qapp.exec()
    │    └ <staticmethod(<built-in method exec of Shiboken.ObjectType object at 0x1238c8810>)>
    └ <PySide6.QtWidgets.QApplication(0x12444e790) at 0x1110ce200>

> File "site-packages/vnpy_ctabacktester/ui/widget.py", line 299, in process_backtesting_finished_event
    self.chart.set_data(df)
    │    │     │        └             close_price  pre_close                                             trades  trade_count  ...    return    highleve...
    │    │     └ <function BacktesterChart.set_data at 0x111097920>
    │    └ <vnpy_ctabacktester.ui.widget.BacktesterChart(0x307356010) at 0x175f891c0>
    └ <vegatrade.core.cta_backtester.ui.widget.BacktesterManager(0x302a86e80) at 0x1519b7f80>
  File "site-packages/vnpy_ctabacktester/ui/widget.py", line 820, in set_data
    self.balance_curve.setData(df["balance"])
    │    │             │       └             close_price  pre_close                                             trades  trade_count  ...    return    highleve...
    │    │             └ <function PlotDataItem.setData at 0x110383a60>
    │    └ <pyqtgraph.graphicsItems.PlotDataItem.PlotDataItem(0x3041bc920, parent=0x302a90df0, pos=0,0, flags=(ItemHasNoContents|ItemSen...
    └ <vnpy_ctabacktester.ui.widget.BacktesterChart(0x307356010) at 0x175f891c0>
  File "site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 1184, in setData
    dt = dataType(data)
         │        └ date
         │          2020-11-11    40000.0000
         │          2020-11-12    40000.0000
         │          2020-11-13    40000.0000
         │          2020-11-16    40000.0000
         │          2020-11-17    40000....
         └ <function dataType at 0x1103823e0>
  File "site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 1856, in dataType
    first = obj[0]
            └ date
              2020-11-11    40000.0000
              2020-11-12    40000.0000
              2020-11-13    40000.0000
              2020-11-16    40000.0000
              2020-11-17    40000....
  File "site-packages/pandas/core/series.py", line 959, in __getitem__
    return self._get_value(key)
           │    │          └ 0
           │    └ <function Series._get_value at 0x103bd5080>
           └ date
             2020-11-11    40000.0000
             2020-11-12    40000.0000
             2020-11-13    40000.0000
             2020-11-16    40000.0000
             2020-11-17    40000....
  File "site-packages/pandas/core/series.py", line 1046, in _get_value
    loc = self.index.get_loc(label)
          │    │             └ 0
          │    └ <pandas._libs.properties.AxisProperty object at 0x103bb61d0>
          └ date
            2020-11-11    40000.0000
            2020-11-12    40000.0000
            2020-11-13    40000.0000
            2020-11-16    40000.0000
            2020-11-17    40000....
  File "site-packages/pandas/core/indexes/base.py", line 3648, in get_loc
    raise KeyError(key) from err
                   └ 0

KeyError: 0
Traceback (most recent call last):
  File "site-packages/pandas/core/indexes/base.py", line 3641, in get_loc
    return self._engine.get_loc(casted_key)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "pandas/_libs/index.pyx", line 168, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 197, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7668, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7676, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 0

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "site-packages/vnpy_ctabacktester/ui/widget.py", line 299, in process_backtesting_finished_event
    self.chart.set_data(df)
    ~~~~~~~~~~~~~~~~~~~^^^^
  File "site-packages/vnpy_ctabacktester/ui/widget.py", line 820, in set_data
    self.balance_curve.setData(df["balance"])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 1184, in setData
    dt = dataType(data)
  File "site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 1856, in dataType
    first = obj[0]
            ~~~^^^
  File "site-packages/pandas/core/series.py", line 959, in __getitem__
    return self._get_value(key)
           ~~~~~~~~~~~~~~~^^^^^
  File "site-packages/pandas/core/series.py", line 1046, in _get_value
    loc = self.index.get_loc(label)
  File "site-packages/pandas/core/indexes/base.py", line 3648, in get_loc
    raise KeyError(key) from err
KeyError: 0
```